### PR TITLE
fix(parse): add end character to all patterns

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -8,10 +8,10 @@ const langs = { es: langEs, en: langEn }
   Data patterns
 */
 const patterns = {
-  message: /^\+RESP/,
-  ack: /^\+ACK/,
-  buffer: /^\+BUFF/,
-  heartbeat: /^\+ACK:GTHBD/
+  message: /^\+RESP.+\$$/,
+  ack: /^\+ACK.+\$$/,
+  buffer: /^\+BUFF.+\$$/,
+  heartbeat: /^\+ACK:GTHBD.+\$$/
 }
 
 /*

--- a/test/test.js
+++ b/test/test.js
@@ -255,6 +255,15 @@ describe('queclink-parzer', () => {
       expect(data.cid).to.eql(24897)
       expect(data.odometer).to.eql(0)
     })
+
+    it('should parse a incomplete raw data as UNKNOWN type', () => {
+      const raw = Buffer.from(
+        '+RESP:GTERI,350502,135790246811220,,00000002,13740,11,1,1,3.3,150,516.8,-70.640961,-33.374944,20210914170'
+      )
+      const data = queclink.parse(raw)
+      expect(data.raw).to.eql(raw.toString())
+      expect(data.type).to.eql('UNKNOWN')
+    })
   })
   describe('isQueclink', () => {
     it('should return true', () => {


### PR DESCRIPTION
Este fix permite que tome como validos datos incompletos como este `+RESP:GTERI,350502,135790246811220,,00000002,13740,11,1,1,3.3,150,516.8,-70.640961,-33.374944,20210914170`.

Para ello se agrega a los patterns que deben finalizar con el caracter `$`.